### PR TITLE
Add context menu entries for Mermaid chart preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -705,6 +705,27 @@
       ]
     },
     "menus": {
+      "editor/title": [
+        {
+          "command": "preview.mermaidChart.preview",
+          "when": "(resourceExtname =~ /^\\.(mmd|mermaid)$/ || resourceLangId =~ /^mermaid/) && mermaidPreview:isActive",
+          "group": "navigation@50"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "preview.mermaidChart.preview",
+          "when": "(resourceExtname =~ /^\\.(mmd|mermaid)$/ || resourceLangId =~ /^mermaid/) && mermaidPreview:isActive",
+          "group": "navigation@50"
+        }
+      ],
+      "openEditors/context": [
+        {
+          "command": "preview.mermaidChart.preview",
+          "when": "(resourceExtname =~ /^\\.(mmd|mermaid)$/ || resourceLangId =~ /^mermaid/) && mermaidPreview:isActive",
+          "group": "navigation@50"
+        }
+      ],
       "view/title": [
         {
           "command": "preview.mermaidChart.refresh",
@@ -794,6 +815,7 @@
       {
         "command": "preview.mermaidChart.preview",
         "title": "Preview Diagram",
+        "icon": "$(open-preview)",
         "category": "Mermaid Preview",
         "when": "mermaidPreview:isActive"
       },


### PR DESCRIPTION
Adds first-class UI entry points for previewing standalone Mermaid files. 

No new runtime command is introduced; all menu entries delegate to the existing preview command.

The extension already supported `preview.mermaidChart.preview`, but the command was only exposed through the command palette and editor context menu. This change makes the same command available from the editor title bar, the Explorer file context menu, and the Open Editors context menu for `.mmd`, `.mermaid`, and Mermaid language documents.

Uses the built-in `$(open-preview)` codicon so the editor title action matches VS Code's Markdown preview-to-side look-and-feel.

---

**Example 1:** Upper right corner; preview of a `.mmd` file:

<img width="677" height="270" alt="Screenshot 2026-06-01 at 12 44 30" src="https://github.com/user-attachments/assets/52dde33d-3b2d-4b7e-9804-02afcca10cb9" />

---

**Example 2:** Right click on a `.mmd` file; in file-explorer menu options:

<img width="368" height="140" alt="Screenshot 2026-06-01 at 12 45 13" src="https://github.com/user-attachments/assets/ce9911b2-6cf6-463c-b921-886d0f7081d5" />
