### PR TITLE
PLUG-121 Implement Settings section with telemetry and popup opt-out

### DIFF
--- a/package.json
+++ b/package.json
@@ -639,6 +639,16 @@
           "type": "string",
           "default": "https://www.mermaid.ai",
           "description": "Base URL used for extension usage analytics"
+        },
+        "preview.mermaid.enableTelemetry": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow Mermaid Preview to send anonymous preview failure analytics. Turn this off to stop all analytics. VS Code's telemetry setting must also be enabled."
+        },
+        "preview.mermaid.showFeaturePopups": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show notifications when a feature has moved to the Mermaid Chart extension."
         }
       }
     },
@@ -673,6 +683,11 @@
           "command": "preview.mermaidChart.reloadSidebar",
           "when": "view == preview_mermaidWebview && mermaidPreview:isActive",
           "group": "navigation@2"
+        },
+        {
+          "command": "preview.mermaidChart.openSettings",
+          "when": "view == preview_mermaidWebview && mermaidPreview:isActive",
+          "group": "navigation@3"
         }
       ],
       "view/item/context": [
@@ -725,6 +740,16 @@
         "icon": {
           "light": "images/icons/refresh-light.svg",
           "dark": "images/icons/refresh-dark.svg"
+        },
+        "category": "Mermaid Preview",
+        "when": "mermaidPreview:isActive"
+      },
+      {
+        "command": "preview.mermaidChart.openSettings",
+        "title": "Settings",
+        "icon": {
+          "light": "images/icons/settings-light.svg",
+          "dark": "images/icons/settings-dark.svg"
         },
         "category": "Mermaid Preview",
         "when": "mermaidPreview:isActive"

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,6 +1,7 @@
 import httpClient from './httpClient';
 import * as vscode from "vscode";
 import * as packageJson from '../package.json';
+import { isPreviewTelemetryEnabled } from "./settings";
 
 export interface PulseEventOptions {
   errorMessage?: string;
@@ -11,7 +12,7 @@ export interface PulseEventOptions {
 class Analytics {
 
   public sendEvent(eventName: string, eventID: string, options?: PulseEventOptions) {
-    if (!vscode.env.isTelemetryEnabled) {
+    if (!isPreviewTelemetryEnabled()) {
       return;
     }
     const analyticsID = vscode.env.machineId;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { extendMarkdownItWithMermaid } from "./previewmarkdown/shared-md-mermaid
 import { checkForOfficialExtension } from "./conflictHandle";
 import { clearTmLanguageCache } from "./syntaxHighlighter";
 import { MermaidWebviewProvider } from "./panels/sidebarPanel";
+import { shouldShowFeaturePopups } from "./settings";
 
 let diagramMappings: { [key: string]: string[] } = require('../src/diagramTypeWords.json');
 let isExtensionStarted = false;
@@ -31,6 +32,10 @@ const movedFeatureMessage =
   "Mermaid Preview Alert: This functionality has moved to the Mermaid Chart extension. Click Show more to understand more.";
 
 async function showMovedFeaturePopup(context: vscode.ExtensionContext) {
+  if (!shouldShowFeaturePopups()) {
+    return;
+  }
+
   const choice = await vscode.window.showInformationMessage(
     movedFeatureMessage,
     "Show more",
@@ -68,6 +73,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.registerWebviewViewProvider("preview_mermaidWebview", mermaidWebviewProvider),
     vscode.commands.registerCommand("preview.mermaidChart.reloadSidebar", () => {
       mermaidWebviewProvider.refresh();
+    }),
+    vscode.commands.registerCommand("preview.mermaidChart.openSettings", () => {
+      mermaidWebviewProvider.toggleView("settings");
     })
   );
 

--- a/src/panels/sidebarPanel.ts
+++ b/src/panels/sidebarPanel.ts
@@ -1,13 +1,30 @@
 import * as vscode from "vscode";
-import { generateWebviewContent } from "../templates/sidebarTemplate";
-import { MERMAID_CHART_EXTENSION_ID } from "../conflictHandle";
+import { generateWebviewContent, SidebarView } from "../templates/sidebarTemplate";
+import { MERMAID_CHART_EXTENSION_ID, THIS_EXTENSION_ID } from "../conflictHandle";
+import {
+  enableTelemetrySetting,
+  showFeaturePopupsSetting,
+  updatePreviewSetting,
+} from "../settings";
 
 export class MermaidWebviewProvider implements vscode.WebviewViewProvider {
   private context: vscode.ExtensionContext;
   private _view?: vscode.WebviewView;
+  private currentView: SidebarView = "home";
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (
+          event.affectsConfiguration(enableTelemetrySetting) ||
+          event.affectsConfiguration(showFeaturePopupsSetting) ||
+          event.affectsConfiguration("telemetry.telemetryLevel")
+        ) {
+          this.postSettings();
+        }
+      })
+    );
   }
 
   resolveWebviewView(webviewView: vscode.WebviewView) {
@@ -20,16 +37,34 @@ export class MermaidWebviewProvider implements vscode.WebviewViewProvider {
       ],
     };
     this.updateWebviewContent();
+    this.postCurrentView();
+    this.postSettings();
 
-    webviewView.webview.onDidReceiveMessage((message) => {
+    webviewView.webview.onDidReceiveMessage(async (message) => {
       if (message.command === "openPreview") {
-        vscode.commands.executeCommand("preview.mermaidChart.createMermaidFile");
+        await vscode.commands.executeCommand("preview.mermaidChart.createMermaidFile");
       }
       if (message.command === "getExtension") {
-        vscode.commands.executeCommand(
+        await vscode.commands.executeCommand(
           "workbench.extensions.search",
           `@id:${MERMAID_CHART_EXTENSION_ID}`
         );
+      }
+      if (message.command === "setTelemetry" && typeof message.enabled === "boolean") {
+        await updatePreviewSetting("enableTelemetry", message.enabled);
+      }
+      if (message.command === "setFeaturePopups" && typeof message.enabled === "boolean") {
+        await updatePreviewSetting("showFeaturePopups", message.enabled);
+      }
+      if (message.command === "openSettings") {
+        await vscode.commands.executeCommand(
+          "workbench.action.openSettings",
+          `@ext:${THIS_EXTENSION_ID}`
+        );
+      }
+      if (message.command === "ready") {
+        this.postCurrentView();
+        this.postSettings();
       }
     });
   }
@@ -37,12 +72,35 @@ export class MermaidWebviewProvider implements vscode.WebviewViewProvider {
   refresh() {
     if (this._view) {
       this.updateWebviewContent();
+      this.postCurrentView();
+      this.postSettings();
     }
+  }
+
+  async toggleView(view: SidebarView) {
+    this.currentView = this.currentView === view ? "home" : view;
+    await vscode.commands.executeCommand("preview_mermaidWebview.focus");
+    this.postCurrentView();
+    this.postSettings();
   }
 
   private updateWebviewContent() {
     if (this._view) {
       this._view.webview.html = generateWebviewContent(this._view.webview, this.context.extensionUri);
     }
+  }
+
+  private postCurrentView() {
+    this._view?.webview.postMessage({ command: "showView", view: this.currentView });
+  }
+
+  private postSettings() {
+    const configuration = vscode.workspace.getConfiguration("preview.mermaid");
+    this._view?.webview.postMessage({
+      command: "settingsChanged",
+      enableTelemetry: configuration.get<boolean>("enableTelemetry", true),
+      showFeaturePopups: configuration.get<boolean>("showFeaturePopups", true),
+      vscodeTelemetryEnabled: vscode.env.isTelemetryEnabled,
+    });
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,24 @@
+import * as vscode from "vscode";
+
+const configSection = "preview.mermaid";
+
+export const enableTelemetrySetting = `${configSection}.enableTelemetry`;
+export const showFeaturePopupsSetting = `${configSection}.showFeaturePopups`;
+
+export function isPreviewTelemetryEnabled(): boolean {
+  return vscode.env.isTelemetryEnabled &&
+    vscode.workspace.getConfiguration(configSection).get<boolean>("enableTelemetry", true);
+}
+
+export function shouldShowFeaturePopups(): boolean {
+  return vscode.workspace.getConfiguration(configSection).get<boolean>("showFeaturePopups", true);
+}
+
+export async function updatePreviewSetting(
+  setting: "enableTelemetry" | "showFeaturePopups",
+  value: boolean
+): Promise<void> {
+  await vscode.workspace
+    .getConfiguration(configSection)
+    .update(setting, value, vscode.ConfigurationTarget.Global);
+}

--- a/src/templates/sidebarTemplate.ts
+++ b/src/templates/sidebarTemplate.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
 
+export type SidebarView = "home" | "settings";
+
 export function generateWebviewContent(
   webview: vscode.Webview,
   extensionUri: vscode.Uri
@@ -9,6 +11,12 @@ export function generateWebviewContent(
   );
   const fontUrl = webview.asWebviewUri(
     vscode.Uri.joinPath(extensionUri, "media","recursive-latin-full-normal.woff2")
+  );
+  const settingsIconDark = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, "images", "icons", "settings-dark.svg")
+  );
+  const settingsIconLight = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, "images", "icons", "settings-light.svg")
   );
   
 
@@ -53,13 +61,20 @@ export function generateWebviewContent(
       --card-bg: rgba(0, 0, 0, 0.03);
     }
 
-    #view-home {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      text-align: center;
+    .view {
+      display: none;
       padding: 16px;
       box-sizing: border-box;
+    }
+
+    .view.is-active {
+      display: flex;
+      flex-direction: column;
+    }
+
+    #view-home {
+      align-items: center;
+      text-align: center;
     }
 
     .logo {
@@ -111,7 +126,7 @@ export function generateWebviewContent(
 
     /* The bundled Recursive subset has no arrow glyphs, so without this the
        arrow falls back to a thin, undersized serif glyph. */
-    .upsell-link .arrow {
+    .arrow {
       font-family: var(--vscode-font-family, system-ui);
       font-size: 14px;
       line-height: 1;
@@ -137,10 +152,92 @@ export function generateWebviewContent(
     .split-note p {
       margin: 0;
     }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 20px;
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    .section-header .glyph {
+      width: 14px;
+      height: 14px;
+    }
+
+    .vscode-light .dark-icon,
+    .vscode-dark .light-icon,
+    .vscode-high-contrast .light-icon {
+      display: none;
+    }
+
+    .setting-row {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+
+    .setting-label {
+      margin: 0;
+      font-size: 13px;
+    }
+
+    .setting-description {
+      margin: 2px 0 0 0;
+      color: var(--text-color);
+      font-size: 11px;
+      line-height: 15px;
+    }
+
+    .toggle {
+      position: relative;
+      flex: 0 0 auto;
+      width: 32px;
+      height: 16px;
+      margin-top: 2px;
+      padding: 0;
+      border: none;
+      border-radius: 999px;
+      background: #4A4A55;
+      cursor: pointer;
+    }
+
+    .toggle::after {
+      content: "";
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: #E9E9EF;
+      transition: left 120ms ease-in-out;
+    }
+
+    .toggle[aria-checked="true"] {
+      background: var(--pink-color);
+    }
+
+    .toggle[aria-checked="true"]::after {
+      left: 18px;
+    }
+
+    .settings-link {
+      align-self: flex-start;
+      margin-top: 8px;
+      color: inherit;
+      font-size: 12px;
+      text-decoration: underline;
+      cursor: pointer;
+    }
     </style>
 </head>
 <body>
-    <section id="view-home">
+    <section id="view-home" class="view is-active">
         <img class="logo" src="${logoSrc}" alt="Mermaid Preview logo">
         <p class="intro">Generate, edit, and preview diagrams right in your editor for free.</p>
         <button id="openPreview" class="open-preview-btn">Open preview</button>
@@ -156,8 +253,36 @@ export function generateWebviewContent(
         </div>
     </section>
 
+    <section id="view-settings" class="view">
+        <div class="section-header">
+            <img class="glyph dark-icon" src="${settingsIconDark}" alt="">
+            <img class="glyph light-icon" src="${settingsIconLight}" alt="">
+            <span>Settings</span>
+        </div>
+
+        <div class="setting-row">
+            <div>
+                <p class="setting-label">Share usage analytics</p>
+                <p id="telemetryDescription" class="setting-description">On by default. Render bugs only.</p>
+            </div>
+            <button id="telemetryToggle" class="toggle" role="switch" aria-checked="true" aria-label="Share usage analytics"></button>
+        </div>
+
+        <div class="setting-row">
+            <div>
+                <p class="setting-label">"Feature moved" popups</p>
+                <p class="setting-description">Notices when a feature moved to Mermaid Chart.</p>
+            </div>
+            <button id="featurePopupsToggle" class="toggle" role="switch" aria-checked="true" aria-label="Feature moved popups"></button>
+        </div>
+
+        <a id="openSettings" class="settings-link">Open VS code Mermaid settings <span class="arrow">&#10132;</span></a>
+    </section>
+
     <script>
         const vscode = acquireVsCodeApi();
+        const telemetryToggle = document.getElementById('telemetryToggle');
+        const featurePopupsToggle = document.getElementById('featurePopupsToggle');
 
         document.getElementById('openPreview').addEventListener('click', () => {
             vscode.postMessage({ command: 'openPreview' });
@@ -166,6 +291,43 @@ export function generateWebviewContent(
         document.getElementById('getExtension').addEventListener('click', () => {
             vscode.postMessage({ command: 'getExtension' });
         });
+
+        telemetryToggle.addEventListener('click', () => {
+            vscode.postMessage({
+                command: 'setTelemetry',
+                enabled: telemetryToggle.getAttribute('aria-checked') !== 'true'
+            });
+        });
+
+        featurePopupsToggle.addEventListener('click', () => {
+            vscode.postMessage({
+                command: 'setFeaturePopups',
+                enabled: featurePopupsToggle.getAttribute('aria-checked') !== 'true'
+            });
+        });
+
+        document.getElementById('openSettings').addEventListener('click', () => {
+            vscode.postMessage({ command: 'openSettings' });
+        });
+
+        window.addEventListener('message', (event) => {
+            if (event.data?.command === 'showView') {
+                document.querySelectorAll('.view').forEach((section) => {
+                    section.classList.toggle('is-active', section.id === 'view-' + event.data.view);
+                });
+            }
+
+            if (event.data?.command === 'settingsChanged') {
+                telemetryToggle.setAttribute('aria-checked', String(event.data.enableTelemetry));
+                featurePopupsToggle.setAttribute('aria-checked', String(event.data.showFeaturePopups));
+                document.getElementById('telemetryDescription').textContent =
+                    event.data.vscodeTelemetryEnabled
+                        ? 'On by default. Render bugs only.'
+                        : 'Disabled by VS Code telemetry settings.';
+            }
+        });
+
+        vscode.postMessage({ command: 'ready' });
     </script>
 </body>
 </html>`;


### PR DESCRIPTION

Adds a Settings view to the Preview sidebar with two toggles, and wires both to real extension behavior. A gear icon in the sidebar title bar opens it; clicking again returns to Home.

**Share usage analytics** — When off, `analytics.sendEvent` returns early, so no pulse events are sent at all (including the PLUG-123 render-failure event). VS Code's own telemetry setting still takes precedence: with `telemetry.telemetryLevel: off` nothing is sent even when the toggle is on, and the row's caption changes to "Disabled by VS Code telemetry settings." to explain why.

**"Feature moved" popups** — When off, `showMovedFeaturePopup` returns before showing anything, so Sync / Connect / Link go quiet. `Ctrl/Cmd+S` still saves the local file. This covers the "settings opt-out stops the popups" acceptance criterion from PLUG-122.

Both default to **on**, so behavior is unchanged for existing users. Turning a toggle off is an explicit user action.

=
