### PR TITLE
PLUG-125 Write What's New and CHANGELOG for OSS Preview split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Change Log
 
+### 2.2.0 
+
+Mermaid Preview is now focused on free, local diagram previewing.
+
+#### What remains in Preview
+
+- Live Mermaid preview with pan, zoom, and reset
+- PNG and SVG export
+- Mermaid rendering in Markdown preview
+- Syntax highlighting, snippets, diagram templates, and Diagram help
+- Local sidebar home and settings
+
+#### What moved to Mermaid Chart
+
+- Login and logout
+- Cloud Sync, Connect, and Link Diagram workflows
+- Mermaid Chart project and diagram browsing
+- AI chat and diagram regeneration
+
+The removed commands now show a notice instead of running their old cloud flows. Users who need account, cloud, or AI features can install the [Mermaid Chart extension](https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart).
+
 ### 2.1.0 -2025-05-13
 ### New Features
 - Added export functionality for SVG and PNG formats

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ### 🚀 Now Proudly Maintained by the Creators of Mermaid.js 🚀
 
+Mermaid Preview is focused on free, local diagram previewing. Account login, cloud sync, and AI features now live in the [Mermaid Chart extension](https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart).
+
 ## Features
 
 ### Works with Latest Mermaid Version
@@ -60,7 +62,7 @@ Export your diagrams easily in both SVG and PNG formats. This makes it simple to
 
 The exported files maintain high quality and can be used across different platforms and tools.
 
-![Export Diagrams](https://docs.mermaidchart.com/img/plugins/vscode-plugin-export.png)
+![Export Diagrams](https://docs.mermaidchart.com/img/plugins/vscode-preview-plugin-export.png)
 
 ### Error Highlighting 
 While writing the mermaid code, if you encounter syntax errors, the extension highlights the syntax error with an error message, and also indicates which line in the code might be causing the error. This helps the user to locate and fix the error. 
@@ -86,7 +88,8 @@ Now based on the diagram type auto suggestions for code snippets will be trigger
 
 ### Diagram Help
 If you get stuck with a diagram's syntax or want to learn about other features for a given diagram, now you can directly access the respective diagram's detailed documentation on the official mermaid.js docs. 
-![Diagram Help](https://docs.mermaidchart.com/img/plugins/vscode-plugin-diagram-help.png)
+
+![Diagram Help](https://docs.mermaidchart.com/img/plugins/vscode-preview-plugin-diagram-help.png)
 
 ### Commands
 
@@ -94,6 +97,9 @@ If you get stuck with a diagram's syntax or want to learn about other features f
 |---------|------------|
 | **Mermaid Preview: Create Diagram** | Creates a new Mermaid diagram in the editor. |
 | **Mermaid Preview: Preview Diagram** | Opens a preview of the selected Mermaid diagram within the editor. |
+| **Mermaid Preview: Diagram help** | Opens the official Mermaid documentation for the current diagram type. |
+| **Mermaid Preview: Settings** | Opens the settings section in the Mermaid Preview sidebar. |
+| **Mermaid Preview: Reload** | Reloads the Mermaid Preview sidebar. |
 
 
 ### Extension Settings
@@ -101,8 +107,34 @@ If you get stuck with a diagram's syntax or want to learn about other features f
 This extension contributes the following settings:
 - `mermaid.vscode.dark_theme`: Defines the theme used for Mermaid diagrams when VS Code is in dark mode.
 - `mermaid.vscode.light_theme`: Defines the theme used for Mermaid diagrams when VS Code is in light mode.
+- `mermaid.vscode.max_Zoom`: Maximum zoom level for diagrams, as a multiple of 100%. A value of `5` means 500%.
+- `mermaid.vscode.max_CharLength`: Maximum number of characters allowed in a diagram's source.
+- `mermaid.vscode.max_Edges`: Maximum number of edges allowed in a diagram's source.
+- `preview.mermaid.enableTelemetry`: Allow Mermaid Preview to send anonymous preview failure analytics. Turn this off to stop all analytics. VS Code's own telemetry setting must also be enabled.
+- `preview.mermaid.showFeaturePopups`: Show notifications when a feature has moved to the Mermaid Chart extension.
+- `preview.mermaid.baseUrl`: Base URL used for extension usage analytics.
 
 ## Release Notes
+### 2.2.0
+Mermaid Preview is now focused on free, local diagram previewing.
+
+#### What remains in Preview
+
+- Live Mermaid preview with pan, zoom, and reset
+- PNG and SVG export
+- Mermaid rendering in Markdown preview
+- Syntax highlighting, snippets, diagram templates, and Diagram help
+- Local sidebar home and settings
+
+#### What moved to Mermaid Chart
+
+- Login and logout
+- Cloud Sync, Connect, and Link Diagram workflows
+- Mermaid Chart project and diagram browsing
+- AI chat and diagram regeneration
+
+The removed commands now show a notice instead of running their old cloud flows. Users who need account, cloud, or AI features can install the [Mermaid Chart extension](https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart).
+
 ### 2.1.1 -2025-05-26
 - Enhanced Sidebar Layout to Improve User Guidance
 

--- a/docs/MermaidPreviewChanges.md
+++ b/docs/MermaidPreviewChanges.md
@@ -1,5 +1,7 @@
 # 🔔 What Changed in Mermaid Preview
 
+## Mermaid Preview 2.2.0
+
 **Mermaid Preview is now a local-only preview extension.**
 
 Everything that needed a Mermaid Chart account has moved to the **[Mermaid Chart](https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart)** extension. Install it to keep using those features.
@@ -14,7 +16,7 @@ These features are no longer part of Mermaid Preview:
 - **Connect Diagram** — attaching a local diagram to a Mermaid Chart project
 - **Link Diagram** — inserting a Mermaid Chart diagram ID into your code
 - **Login / Logout** — Mermaid Chart accounts and sign-in
-- **Side panel** — browsing your Mermaid Chart projects and diagrams
+- **Cloud diagram browser** — browsing Mermaid Chart projects and diagrams in the side panel
 - **Download diagram** — pulling a cloud diagram into your editor
 - **Refresh** — re-syncing the cloud diagram list
 - **Smart sync & conflict detection** — comparing local and remote versions
@@ -35,6 +37,7 @@ Mermaid Preview keeps everything that works without an account:
 - Syntax highlighting for `.mmd` and `.mermaid` files
 - Diagram templates on an empty file, plus snippets while you type
 - **Create Diagram** and **Diagram help**
+- Local sidebar home and settings for Preview
 - Theme, max zoom, max text size, and max edges settings
 
 ---
@@ -45,7 +48,6 @@ Mermaid Preview keeps everything that works without an account:
 2. Sign in with your Mermaid Chart account.
 3. Sync, Connect, Link, and the cloud side panel work there as before.
 
-You can keep both extensions installed — Mermaid Preview stays your local previewer.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Mermaid Preview",
   "description": "Mermaid diagram previewer for Visual Studio Code, now maintained by the creators of Mermaid.js",
   "license": "MIT",
-  "version": "2.1.1",
+  "version": "2.2.0 ",
   "publisher": "vstirbu",
   "bugs": {
     "url": "https://github.com/vstirbu/vscode-mermaid-preview/issues"
@@ -55,7 +55,8 @@
     "virtualWorkspaces": true
   },
   "activationEvents": [
-    "onLanguage"
+    "onLanguage",
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Mermaid Preview",
   "description": "Mermaid diagram previewer for Visual Studio Code, now maintained by the creators of Mermaid.js",
   "license": "MIT",
-  "version": "2.2.0 ",
+  "version": "2.2.0",
   "publisher": "vstirbu",
   "bugs": {
     "url": "https://github.com/vstirbu/vscode-mermaid-preview/issues"
@@ -789,7 +789,7 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm compile",
-    "precompile": "pnpm --filter ./webview build && webpack --mode=production --config ./build/markdownPreview.webpack.config.js",
+    "precompile": "pnpm --filter ./webview build",
     "compile": "tsc -p ./ --noEmit && esbuild ./src/extension.ts --sourcemap --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --minify",
     "watch": "tsc -p ./ --noEmit --watch",
     "pretest": "pnpm compile && pnpm lint",

--- a/package.json
+++ b/package.json
@@ -776,7 +776,7 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm compile",
-    "precompile": "pnpm --filter ./webview build",
+    "precompile": "pnpm --filter ./webview build && webpack --mode=production --config ./build/markdownPreview.webpack.config.js",
     "compile": "tsc -p ./ --noEmit && esbuild ./src/extension.ts --sourcemap --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --minify",
     "watch": "tsc -p ./ --noEmit --watch",
     "pretest": "pnpm compile && pnpm lint",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { checkForOfficialExtension } from "./conflictHandle";
 import { clearTmLanguageCache } from "./syntaxHighlighter";
 import { MermaidWebviewProvider } from "./panels/sidebarPanel";
 import { shouldShowFeaturePopups } from "./settings";
+import { showWhatsNew } from "./whatsNew";
 
 let diagramMappings: { [key: string]: string[] } = require('../src/diagramTypeWords.json');
 let isExtensionStarted = false;
@@ -303,6 +304,12 @@ context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
       vscode.commands.executeCommand('markdown.preview.refresh');
   }
 }));
+
+// Not awaited: activate must return the markdown-it plugin below first, otherwise
+// markdown.showPreview waits on the Markdown extension while it waits on us.
+void showWhatsNew(context).catch((error) => {
+  console.error({ error }, "Failed to show Mermaid Preview release notes");
+});
 
 return {
   extendMarkdownIt(md: MarkdownIt) {

--- a/src/whatsNew.ts
+++ b/src/whatsNew.ts
@@ -1,0 +1,23 @@
+import * as path from "path";
+import * as vscode from "vscode";
+
+/** Set to false before release so each user sees the notes once for this version. */
+const whatsNewAlwaysShowForTesting = true;
+
+const whatsNewVersion = "2.2.0";
+const whatsNewStateKey = "mermaidPreview.whatsNewVersion";
+
+export async function showWhatsNew(context: vscode.ExtensionContext): Promise<void> {
+  const lastShownVersion = context.globalState.get<string>(whatsNewStateKey);
+  if (!whatsNewAlwaysShowForTesting && lastShownVersion === whatsNewVersion) {
+    return;
+  }
+
+  const docPath = path.join(context.extensionPath, "docs", "MermaidPreviewChanges.md");
+  const document = await vscode.workspace.openTextDocument(docPath);
+  await vscode.commands.executeCommand("markdown.showPreview", document.uri);
+
+  if (!whatsNewAlwaysShowForTesting) {
+    await context.globalState.update(whatsNewStateKey, whatsNewVersion);
+  }
+}

--- a/src/whatsNew.ts
+++ b/src/whatsNew.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 /** Set to false before release so each user sees the notes once for this version. */
-const whatsNewAlwaysShowForTesting = true;
+const whatsNewAlwaysShowForTesting = false;
 
 const whatsNewVersion = "2.2.0";
 const whatsNewStateKey = "mermaidPreview.whatsNewVersion";


### PR DESCRIPTION
Existing users now get the same Markdown they already see from the “Show more” popup (`docs/MermaidPreviewChanges.md`) on first activation after this release — not a custom banner. `CHANGELOG.md` has a **2.2.0** entry covering what stayed in Preview vs what moved to Mermaid Chart.

**When it opens**
- `onStartupFinished` was added so this runs after VS Code starts or reloads, not only when a Mermaid file is open.
- Shown once per user for `2.2.0`, stored in `globalState` (`mermaidPreview.whatsNewVersion`).
- `whatsNewAlwaysShowForTesting` is **true** in this PR so Debug mode always opens the preview. **Set it to `false` before shipping** or every reload will keep opening the notes.

**Note:** `package.json` version is `2.2.0`.